### PR TITLE
add @ts-ignore to workaround on Glider init

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -42,6 +42,8 @@ const Carousel: React.FC<CarouselProps> = ({
       }
     }
 
+    // eslint-disable-next-line
+    // @ts-ignore
     const glider = new Glider(elementRef.current, settings)
 
     setIsBiggerThanContainer(glider.trackWidth > glider.containerWidth)


### PR DESCRIPTION
### Descrição da mudança\*

- Shame: ignore ts validation on one line to prevent a problem when initializing Glider carousel on specific element ref


### Checklist de alerta!

- [ ] Foi feito o bump de versão para geração de novo release
- [x] Outros projetos serão afetados com essa mudança
  - Todos projetos linkados com a versão `@latest` da biblioteca serão afetados
