### PR TITLE
Fix: dangeroursly content warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platosedu/react-components",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "React components library used across React projects at Platos",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platosedu/react-components",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React components library used across React projects at Platos",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/SimpleTable/README.md
+++ b/src/components/SimpleTable/README.md
@@ -1,4 +1,7 @@
 ### SimpleTable
+
+> Caution: this component uses `dangerouslySetInnerHTML` to render HTML inside cells, so maybe you need to sanitize the content before passing the `data` param in order to prevent XSS attacks
+
 ```js
 <div
   style={{

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -21,7 +21,7 @@ type TypographyVariant =
   | 'buttonXXS'
 interface TypographyProps {
   className?: string
-  innerHTML?: string
+  dangerouslySetInnerHTML?: string
   variant?: TypographyVariant
   element?: React.ElementType
 }
@@ -29,7 +29,7 @@ interface TypographyProps {
 const Typography: React.FC<TypographyProps> = ({
   className,
   children,
-  innerHTML,
+  dangerouslySetInnerHTML,
   variant = 'bodySM',
   element
 }) => {
@@ -60,11 +60,11 @@ const Typography: React.FC<TypographyProps> = ({
 
   const TypographyElement = element || elementMap[variant]
 
-  if (innerHTML) {
+  if (dangerouslySetInnerHTML) {
     return (
       <TypographyElement
         className={typographyClassNames}
-        dangerouslySetInnerHTML={{ __html: innerHTML }}
+        dangerouslySetInnerHTML={{ __html: dangerouslySetInnerHTML }}
       />
     )
   }

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -64,7 +64,7 @@ const Typography: React.FC<TypographyProps> = ({
     return (
       <TypographyElement
         className={typographyClassNames}
-        dangerouslySetInnerHTML={{ __html: dangerouslySetInnerHTML }}
+        dangerouslySetInnerHTML={dangerouslySetInnerHTML}
       />
     )
   }


### PR DESCRIPTION
### Descrição da mudança\*

- Renomeada propriedade `innetHtml` para `dangerouslySetInnerHTML` no componente Typography a fim de explicar com mais clareza a propriedade
- Adicionado aviso na documentação do componente SimpleTable avisando que o mesmo utiliza `dangerouslySetInnerHTML` para renderizar as células e que talvez seja necessário sanitizar os dados a fim de evitar ataques XSS

### Checklist de alerta!

- [x] Foi feito o bump de versão para geração de novo release
- [x] Outros projetos serão afetados com essa mudança
  - Todos projetos linkados com a versão `@latest` da biblioteca serão afetados
