### PR TITLE
Fix: NavHeader logo size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platosedu/react-components",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "React components library used across React projects at Platos",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platosedu/react-components",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "React components library used across React projects at Platos",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/NavHeader/style.module.scss
+++ b/src/components/NavHeader/style.module.scss
@@ -64,6 +64,7 @@
 .headerLogo img,
 .headerLogo svg {
   max-width: 100%;
+  max-height: calc(var(--size-header-height) - (var(--spacing-xs)*2));
 }
 
 .opened .headerLogo svg {


### PR DESCRIPTION
### Descrição da mudança\*

- Corrigido: altura maxima de imagens no componente logo dentro do NavHeader para previnir a imagem de ultrapassar a altura máxima do header

### Checklist de alerta!

- [x] Foi feito o bump de versão para geração de novo release
- [x] Outros projetos serão afetados com essa mudança
  - Todos projetos linkados com a versão `@latest` da biblioteca serão afetados
