### PR TITLE
Add: FieldTextarea component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platosedu/react-components",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "React components library used across React projects at Platos",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/FieldText/index.tsx
+++ b/src/components/FieldText/index.tsx
@@ -9,7 +9,9 @@ export interface FieldTextProps {
   className?: string
   tabIndex?: number
   value?: string | number
+  defaultValue?: string | number
   label?: string
+  fixedLabel?: boolean
   mask?: string | (string | RegExp)[]
   placeholder?: string
   name?: string
@@ -20,14 +22,7 @@ export interface FieldTextProps {
   required?: boolean
   bordered?: boolean
   error?: string | null
-  type?:
-    | 'text'
-    | 'textarea'
-    | 'password'
-    | 'email'
-    | 'search'
-    | 'number'
-    | 'color'
+  type?: 'text' | 'password' | 'email' | 'search' | 'number' | 'color'
   autocomplete?: 'on' | 'off'
   prefixIcon?: IconSlugsType
   prefixIconPath?: string
@@ -35,191 +30,180 @@ export interface FieldTextProps {
   suffixIcon?: IconSlugsType
   suffixIconPath?: string
   suffixIconComponent?: IconType
-  onChange?: (
-    event:
-      | React.ChangeEvent<HTMLInputElement>
-      | React.ChangeEvent<HTMLTextAreaElement>
-  ) => void
-  onFocus?: (
-    event:
-      | React.FocusEvent<HTMLInputElement>
-      | React.FocusEvent<HTMLTextAreaElement>
-  ) => void
-  onBlur?: (
-    event:
-      | React.FocusEvent<HTMLInputElement>
-      | React.FocusEvent<HTMLTextAreaElement>
-  ) => void
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onFocus?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void
   onPrefixIconClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
   onSuffixIconClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-const FieldText: React.FC<FieldTextProps> = ({
-  name,
-  inputId,
-  className,
-  tabIndex,
-  type = 'text',
-  autocomplete = 'on',
-  label = '',
-  placeholder = '',
-  hint,
-  disabled = false,
-  readOnly = false,
-  required = false,
-  bordered = false,
-  error,
-  onChange,
-  onFocus,
-  onBlur,
-  prefixIcon,
-  prefixIconPath,
-  prefixIconComponent,
-  onPrefixIconClick,
-  suffixIcon,
-  suffixIconPath,
-  suffixIconComponent,
-  onSuffixIconClick,
-  mask,
-  value,
-  ...props
-}) => {
-  const isTextarea = type === 'textarea'
-  const [focused, setFocused] = useState(false)
-  const inputIdFormatted = inputId || `field-${name}`
-  const InputElement = isTextarea ? 'textarea' : 'input'
+const FieldText = React.forwardRef<HTMLInputElement, FieldTextProps>(
+  (
+    {
+      name,
+      inputId,
+      className,
+      tabIndex,
+      type = 'text',
+      autocomplete = 'on',
+      label = '',
+      fixedLabel = false,
+      placeholder = '',
+      hint,
+      disabled = false,
+      readOnly = false,
+      required = false,
+      bordered = false,
+      error,
+      onChange,
+      onFocus,
+      onBlur,
+      prefixIcon,
+      prefixIconPath,
+      prefixIconComponent,
+      onPrefixIconClick,
+      suffixIcon,
+      suffixIconPath,
+      suffixIconComponent,
+      onSuffixIconClick,
+      mask,
+      value,
+      defaultValue,
+      ...props
+    },
+    ref
+  ) => {
+    const [focused, setFocused] = useState(false)
+    const inputIdFormatted = inputId || `field-${name}`
 
-  const handleFocus = (
-    e:
-      | React.FocusEvent<HTMLInputElement>
-      | React.FocusEvent<HTMLTextAreaElement>
-  ): void => {
-    if (onFocus) {
-      onFocus(e)
+    const handleFocus = (e: React.FocusEvent<HTMLInputElement>): void => {
+      if (onFocus) {
+        onFocus(e)
+      }
+
+      setFocused(true)
     }
 
-    setFocused(true)
-  }
+    const handleBlur = (e: React.ChangeEvent<HTMLInputElement>): void => {
+      if (onBlur) {
+        onBlur(e)
+      }
 
-  const handleBlur = (
-    e:
-      | React.FocusEvent<HTMLInputElement>
-      | React.FocusEvent<HTMLTextAreaElement>
-  ): void => {
-    if (onBlur) {
-      onBlur(e)
+      setFocused(false)
     }
 
-    setFocused(false)
+    const hasPrefixIcon = Boolean(
+      prefixIcon || prefixIconPath || prefixIconComponent
+    )
+    const hasSuffixIcon = Boolean(
+      suffixIcon || suffixIconPath || suffixIconComponent
+    )
+
+    const containerClassNames = classNames(style.container, className, {
+      [style.isFocused]: Boolean(focused),
+      [style.isBordered]: Boolean(bordered),
+      [style.isFilled]: Boolean(value) || Boolean(defaultValue),
+      [style.isDisabled]: Boolean(disabled),
+      [style.hasError]: Boolean(error),
+      [style.hasLabel]: Boolean(label),
+      [style.isFixedLabel]: fixedLabel,
+      [style.hasPlaceholder]: Boolean(placeholder),
+      [style.hasPrefixIcon]: hasPrefixIcon,
+      [style.hasSuffixIcon]: hasSuffixIcon
+    })
+
+    return (
+      <div className={containerClassNames}>
+        <label className={style.field} htmlFor={inputIdFormatted}>
+          {hasPrefixIcon ? (
+            <Icon
+              size="md"
+              icon={prefixIcon}
+              iconPath={prefixIconPath}
+              iconComponent={prefixIconComponent}
+              className={classNames(style.prefixIcon, {
+                [style.iconClickable]: Boolean(onPrefixIconClick)
+              })}
+              onClick={onPrefixIconClick}
+            />
+          ) : null}
+
+          {mask ? (
+            <InputMask
+              mask={mask}
+              value={value}
+              defaultValue={defaultValue}
+              onChange={onChange}
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              disabled={disabled}
+              readOnly={readOnly}
+              // maskChar={null}
+            >
+              {(inputProps: InputProps): ReactElement => (
+                <input
+                  {...inputProps}
+                  className={style.input}
+                  id={inputIdFormatted}
+                  tabIndex={tabIndex}
+                  type={type}
+                  autoComplete={autocomplete}
+                  name={name}
+                  placeholder={placeholder}
+                  required={required}
+                  onChange={onChange}
+                  // ref={ref}
+                  {...props}
+                />
+              )}
+            </InputMask>
+          ) : (
+            <input
+              className={style.input}
+              id={inputIdFormatted}
+              tabIndex={tabIndex}
+              type={type}
+              autoComplete={autocomplete}
+              name={name}
+              placeholder={placeholder}
+              required={required}
+              value={value}
+              defaultValue={defaultValue}
+              onChange={onChange}
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              disabled={disabled}
+              readOnly={readOnly}
+              ref={ref}
+              {...props}
+            />
+          )}
+
+          {label && (
+            <span className={style.label}>
+              {label}
+              {required ? '*' : null}
+            </span>
+          )}
+
+          {hasSuffixIcon ? (
+            <Icon
+              size="md"
+              icon={suffixIcon}
+              iconPath={suffixIconPath}
+              iconComponent={suffixIconComponent}
+              className={classNames(style.suffixIcon, {
+                [style.iconClickable]: Boolean(onSuffixIconClick)
+              })}
+              onClick={onSuffixIconClick}
+            />
+          ) : null}
+        </label>
+
+        <p className={style.supportText}>{(error ? error : '') || hint}</p>
+      </div>
+    )
   }
-
-  const hasPrefixIcon = Boolean(
-    prefixIcon || prefixIconPath || prefixIconComponent
-  )
-  const hasSuffixIcon = Boolean(
-    suffixIcon || suffixIconPath || suffixIconComponent
-  )
-
-  const containerClassNames = classNames(style.container, className, {
-    [style.error]: Boolean(error),
-    [style.focused]: Boolean(focused),
-    [style.bordered]: Boolean(bordered),
-    [style.filled]: Boolean(value),
-    [style.hasLabel]: Boolean(label),
-    [style.hasPlaceholder]: Boolean(placeholder),
-    [style.disabled]: Boolean(disabled),
-    [style.hasPrefixIcon]: hasPrefixIcon,
-    [style.hasSuffixIcon]: hasSuffixIcon,
-    [style.isTextarea]: isTextarea
-  })
-
-  return (
-    <div className={containerClassNames}>
-      <label className={style.field} htmlFor={inputIdFormatted}>
-        {hasPrefixIcon ? (
-          <Icon
-            size="md"
-            icon={prefixIcon}
-            iconPath={prefixIconPath}
-            iconComponent={prefixIconComponent}
-            className={classNames(style.prefixIcon, {
-              [style.iconClickable]: Boolean(onPrefixIconClick)
-            })}
-            onClick={onPrefixIconClick}
-          />
-        ) : null}
-
-        {mask ? (
-          <InputMask
-            mask={mask}
-            value={value}
-            onChange={onChange}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            disabled={disabled}
-            readOnly={readOnly}
-            // maskChar={null}
-          >
-            {(inputProps: InputProps): ReactElement => (
-              <input
-                {...inputProps}
-                className={style.input}
-                id={inputIdFormatted}
-                tabIndex={tabIndex}
-                type={type}
-                autoComplete={autocomplete}
-                name={name}
-                placeholder={placeholder}
-                required={required}
-                onChange={onChange}
-                {...props}
-              />
-            )}
-          </InputMask>
-        ) : (
-          <InputElement
-            className={style.input}
-            id={inputIdFormatted}
-            tabIndex={tabIndex}
-            type={type}
-            autoComplete={autocomplete}
-            name={name}
-            placeholder={placeholder}
-            required={required}
-            value={value}
-            onChange={onChange}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            disabled={disabled}
-            readOnly={readOnly}
-            {...props}
-          />
-        )}
-
-        {label && (
-          <span className={style.label}>
-            {label}
-            {required ? '*' : null}
-          </span>
-        )}
-
-        {hasSuffixIcon ? (
-          <Icon
-            size="md"
-            icon={suffixIcon}
-            iconPath={suffixIconPath}
-            iconComponent={suffixIconComponent}
-            className={classNames(style.suffixIcon, {
-              [style.iconClickable]: Boolean(onSuffixIconClick)
-            })}
-            onClick={onSuffixIconClick}
-          />
-        ) : null}
-      </label>
-
-      <p className={style.supportText}>{(error ? error : '') || hint}</p>
-    </div>
-  )
-}
+)
 
 export default FieldText

--- a/src/components/FieldText/style.module.scss
+++ b/src/components/FieldText/style.module.scss
@@ -29,12 +29,6 @@
     padding: var(--spacing-sm) var(--spacing-md) 0;
   }
 
-  .isTextarea & {
-    height: calc(var(--size-field-height) * 2);
-    padding: var(--spacing-lg) var(--spacing-md);
-    resize: vertical;
-  }
-
   &::-webkit-input-placeholder {
     color: var(--color-neutral-light-300);
   }
@@ -47,7 +41,7 @@
     color: var(--color-neutral-light-300);
   }
 
-  .bordered & {
+  .isBordered & {
     border: 1px solid var(--color-neutral-light-200);
   }
 }
@@ -78,12 +72,12 @@
   cursor: pointer;
 }
 
-.disabled .prefixIcon,
-.disabled .suffixIcon {
+.isDisabled .prefixIcon,
+.isDisabled .suffixIcon {
   fill: var(--color-neutral-light-300);
 }
 
-.disabled .input {
+.isDisabled .input {
   color: var(--color-neutral-light-300);
   border-color: var(--color-neutral-light-200);
 }
@@ -102,7 +96,7 @@
   left: calc(var(--spacing-md) + var(--size-icon-sm) + var(--spacing-md));
 }
 
-.disabled .label {
+.isDisabled .label {
   color: var(--color-neutral-light-300);
 }
 
@@ -118,22 +112,22 @@
   text-align: right;
 }
 
-.disabled .supportText {
+.isDisabled .supportText {
   color: var(--color-neutral-light-300);
 }
 
-.focused .input {
+.isFocused .input {
   border-color: var(--color-primary-500);
 }
 
-.focused:not(.bordered) .input {
+.isFocused:not(.isBordered) .input {
   border: 1px solid var(--color-primary-700-opacity);
 }
 
 .hasPlaceholder .label,
-.filled .label,
-.focused .label,
-.isTextarea .label {
+.isFilled .label,
+.isFocused .label,
+.isFixedLabel .label {
   font-size: var(--font-size-xxs);
   top: var(--spacing-sm);
   transform: translateY(-50%);
@@ -144,24 +138,23 @@
 }
 
 .hasPrefixIcon.hasPlaceholder .label,
-.hasPrefixIcon.filled .label,
-.hasPrefixIcon.focused .label,
-.hasPrefixIcon.isTextarea .label {
+.hasPrefixIcon.isFilled .label,
+.hasPrefixIcon.isFocused .label {
   left: calc(var(--spacing-md) + var(--size-icon-sm) + var(--spacing-md));
   width: calc(100% - (var(--spacing-md) + var(--size-icon-sm) + var(--spacing-md)) - 2px);
 }
 
-.focused .label {
+.isFocused .label {
   color: var(--color-primary-500);
 }
 
-.error,
-.error .supportText,
-.error .field .label {
+.hasError,
+.hasError .supportText,
+.hasError .field .label {
   color: var(--color-error-500);
 }
 
-.error .field .input {
+.hasError .field .input {
   border-color: var(--color-error-500);
   caret-color: var(--color-error-500);
 }

--- a/src/components/FieldTextArea/README.md
+++ b/src/components/FieldTextArea/README.md
@@ -1,0 +1,17 @@
+### Normal
+```js
+const [value, setValue] = React.useState('')
+
+const handleChange = (e) => {
+  setValue(e.target.value)
+}
+
+;<div style={{ backgroundColor: "#E0E0E0", padding: "1rem" }}>
+  <FieldTextArea
+    name="name-0"
+    label="Mensagem"
+    value={value}
+    onChange={handleChange}
+  />
+</div>
+```

--- a/src/components/FieldTextArea/index.tsx
+++ b/src/components/FieldTextArea/index.tsx
@@ -1,0 +1,165 @@
+import React, { ReactElement, useState } from 'react'
+import classNames from 'classnames'
+import Icon, { IconSlugsType } from '../Icon'
+import { IconType } from 'react-icons'
+import InputMask, { Props as InputProps } from 'react-input-mask'
+import style from './style.module.scss'
+
+export interface FieldTextAreaProps {
+  className?: string
+  tabIndex?: number
+  value?: string | number
+  defaultValue?: string | number
+  label?: string
+  placeholder?: string
+  name?: string
+  inputId?: string
+  hint?: string | null
+  disabled?: boolean
+  readOnly?: boolean
+  required?: boolean
+  bordered?: boolean
+  error?: string | null
+  prefixIcon?: IconSlugsType
+  prefixIconPath?: string
+  prefixIconComponent?: IconType
+  suffixIcon?: IconSlugsType
+  suffixIconPath?: string
+  suffixIconComponent?: IconType
+  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
+  onFocus?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
+  onBlur?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
+  onPrefixIconClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
+  onSuffixIconClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+const FieldTextArea = React.forwardRef<HTMLTextAreaElement, FieldTextAreaProps>(
+  (
+    {
+      name,
+      inputId,
+      className,
+      tabIndex,
+      label = '',
+      placeholder = '',
+      hint,
+      disabled = false,
+      readOnly = false,
+      required = false,
+      bordered = false,
+      error,
+      onChange,
+      onFocus,
+      onBlur,
+      prefixIcon,
+      prefixIconPath,
+      prefixIconComponent,
+      onPrefixIconClick,
+      suffixIcon,
+      suffixIconPath,
+      suffixIconComponent,
+      onSuffixIconClick,
+      value,
+      defaultValue,
+      ...props
+    },
+    ref
+  ) => {
+    const [focused, setFocused] = useState(false)
+    const inputIdFormatted = inputId || `field-${name}`
+
+    const handleFocus = (e: React.FocusEvent<HTMLTextAreaElement>): void => {
+      if (onFocus) {
+        onFocus(e)
+      }
+
+      setFocused(true)
+    }
+
+    const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>): void => {
+      if (onBlur) {
+        onBlur(e)
+      }
+
+      setFocused(false)
+    }
+
+    const hasPrefixIcon = Boolean(
+      prefixIcon || prefixIconPath || prefixIconComponent
+    )
+    const hasSuffixIcon = Boolean(
+      suffixIcon || suffixIconPath || suffixIconComponent
+    )
+
+    const containerClassNames = classNames(style.container, className, {
+      [style.isFocused]: Boolean(focused),
+      [style.isBordered]: Boolean(bordered),
+      [style.isDisabled]: Boolean(disabled),
+      [style.hasError]: Boolean(error),
+      [style.hasLabel]: Boolean(label),
+      [style.hasPrefixIcon]: hasPrefixIcon,
+      [style.hasSuffixIcon]: hasSuffixIcon
+    })
+
+    return (
+      <div className={containerClassNames}>
+        <label className={style.field} htmlFor={inputIdFormatted}>
+          {hasPrefixIcon ? (
+            <Icon
+              size="md"
+              icon={prefixIcon}
+              iconPath={prefixIconPath}
+              iconComponent={prefixIconComponent}
+              className={classNames(style.prefixIcon, {
+                [style.iconClickable]: Boolean(onPrefixIconClick)
+              })}
+              onClick={onPrefixIconClick}
+            />
+          ) : null}
+
+          <textarea
+            className={style.input}
+            id={inputIdFormatted}
+            tabIndex={tabIndex}
+            name={name}
+            placeholder={placeholder}
+            required={required}
+            value={value}
+            defaultValue={defaultValue}
+            onChange={onChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            disabled={disabled}
+            readOnly={readOnly}
+            ref={ref}
+            {...props}
+          />
+
+          {label && (
+            <span className={style.label}>
+              {label}
+              {required ? '*' : null}
+            </span>
+          )}
+
+          {hasSuffixIcon ? (
+            <Icon
+              size="md"
+              icon={suffixIcon}
+              iconPath={suffixIconPath}
+              iconComponent={suffixIconComponent}
+              className={classNames(style.suffixIcon, {
+                [style.iconClickable]: Boolean(onSuffixIconClick)
+              })}
+              onClick={onSuffixIconClick}
+            />
+          ) : null}
+        </label>
+
+        <p className={style.supportText}>{(error ? error : '') || hint}</p>
+      </div>
+    )
+  }
+)
+
+export default FieldTextArea

--- a/src/components/FieldTextArea/style.module.scss
+++ b/src/components/FieldTextArea/style.module.scss
@@ -1,0 +1,146 @@
+.container {
+  position: relative;
+  margin-bottom: var(--spacing-lg);
+}
+
+.field {
+  display: flex;
+  position: relative;
+  align-items: center;
+}
+
+.input {
+  margin: 0;
+  width: 100%;
+  border-radius: var(--border-radius-sm);
+  height: calc(var(--size-field-height) * 2);
+  padding: var(--spacing-lg) var(--spacing-md);
+  resize: vertical;
+  box-sizing: border-box;
+  outline: none;
+  background-color: var(--color-white);
+  transition: color 200ms ease;
+
+  font: var(--font-weight-regular) var(--font-size-sm) var(--font-family);
+  color: var(--color-neutral-light-900);
+  caret-color: var(--color-primary-500);
+  border: unset;
+
+  .hasLabel & {
+    padding: var(--spacing-sm) var(--spacing-md) 0;
+  }
+
+  &::-webkit-input-placeholder {
+    color: var(--color-neutral-light-300);
+  }
+
+  &:-ms-input-placeholder {
+    color: var(--color-neutral-light-300);
+  }
+
+  &::placeholder {
+    color: var(--color-neutral-light-300);
+  }
+
+  .isBordered & {
+    border: 1px solid var(--color-neutral-light-200);
+  }
+}
+
+.hasPrefixIcon .input {
+  padding-left: calc(var(--spacing-md) + var(--size-icon-sm) + var(--spacing-md));
+}
+
+.hasSuffixIcon .input {
+  padding-right: calc(var(--spacing-md) + var(--size-icon-sm) + var(--spacing-md));
+}
+
+.prefixIcon,
+.suffixIcon {
+  position: absolute;
+  left: var(--spacing-md);
+  display: flex;
+  align-self: center;
+  fill: var(--color-neutral-light-600);
+}
+
+.suffixIcon {
+  left: unset;
+  right: var(--spacing-md);
+}
+
+.iconClickable {
+  cursor: pointer;
+}
+
+.isDisabled .prefixIcon,
+.isDisabled .suffixIcon {
+  fill: var(--color-neutral-light-300);
+}
+
+.isDisabled .input {
+  color: var(--color-neutral-light-300);
+  border-color: var(--color-neutral-light-200);
+}
+
+.label {
+  position: absolute;
+  font: var(--font-weight-regular) var(--font-size-sm) var(--font-family);
+  transition: all 200ms ease;
+  color: var(--color-neutral-light-600);
+  font-size: var(--font-size-xxs);
+  top: var(--spacing-sm);
+  transform: translateY(-50%);
+  padding: 2px;
+  left: calc(var(--spacing-md) - 2px);
+  width: calc(100% - var(--spacing-md));
+  background-color: var(--color-white);
+}
+
+.hasPrefixIcon .label {
+  left: calc(var(--spacing-md) + var(--size-icon-sm) + var(--spacing-md));
+  width: calc(100% - (var(--spacing-md) + var(--size-icon-sm) + var(--spacing-md)) - 2px);
+}
+
+.isDisabled .label {
+  color: var(--color-neutral-light-300);
+}
+
+.supportText {
+  position: absolute;
+  bottom: 0;
+  transform: translateY(100%);
+  margin: 0;
+  padding: var(--spacing-xxs) var(--spacing-xs) 0;
+  font: var(--font-weight-regular) var(--font-size-xxs) var(--font-family);
+  color: var(--color-neutral-light-600);
+  width: 100%;
+  text-align: right;
+}
+
+.isDisabled .supportText {
+  color: var(--color-neutral-light-300);
+}
+
+.isFocused .input {
+  border-color: var(--color-primary-500);
+}
+
+.isFocused:not(.isBordered) .input {
+  border: 1px solid var(--color-primary-700-opacity);
+}
+
+.isFocused .label {
+  color: var(--color-primary-500);
+}
+
+.hasError,
+.hasError .supportText,
+.hasError .field .label {
+  color: var(--color-error-500);
+}
+
+.hasError .field .input {
+  border-color: var(--color-error-500);
+  caret-color: var(--color-error-500);
+}

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import icons from './icons/icons.json'
 import style from './style.module.scss'
 
+// The IconSlugsType is one of keys of icons collection
 export type IconSlugsType = keyof typeof icons
 
 interface IconProps {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import CircledInfo from './components/CircledInfo'
 import ProductCard from './components/ProductCard'
 import Dropdown from './components/Dropdown'
 import FieldText from './components/FieldText'
+import FieldTextArea from './components/FieldTextArea'
 import Icon from './components/Icon'
 import ImgMask from './components/ImgMask'
 import LoadingIcon from './components/LoadingIcon'
@@ -27,6 +28,7 @@ export {
   ProductCard,
   Dropdown,
   FieldText,
+  FieldTextArea,
   Icon,
   ImgMask,
   LoadingIcon,


### PR DESCRIPTION
### Descrição da mudança\*

- Adicionado: componente `FieldTextarea`
- Removido: possibilidade de passar propriedade `type="textarea"` para componente `FieldText`
- Atualizado: componente `FieldText` agora utiliza `React.forwardRef` para garantir controle por react-hook-form

#### Criação de novo componente: FieldTextarea

- [ ] - Foram escritos testes para o componente
- [x] - Componente foi disponibilizado na documentação (Styleguidist)

### Checklist de alerta!

- [x] Foi feito o bump de versão para geração de novo release
- [x] Outros projetos serão afetados com essa mudança
  - Todos projetos linkados com a versão `@latest` da biblioteca serão afetados
